### PR TITLE
Textures module

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,14 @@
 use audio::AudioPlugin;
 use bevy::prelude::*;
+use textures::TexturesPlugin;
 
 mod audio;
+mod textures;
 
 fn main() {
     let mut app = App::new();
 
-    app.add_plugins((DefaultPlugins, AudioPlugin));
+    app.add_plugins((DefaultPlugins, AudioPlugin, TexturesPlugin));
 
     app.run();
 }

--- a/src/textures.rs
+++ b/src/textures.rs
@@ -1,0 +1,54 @@
+use bevy::{
+    asset::{LoadedFolder, RecursiveDependencyLoadState},
+    prelude::*,
+};
+
+pub const ASSET_FOLDER_TEXTURES: &str = "textures";
+
+pub struct TexturesPlugin;
+
+impl Plugin for TexturesPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<TexturesLoadState>();
+        app.init_resource::<TextureFolderHandle>();
+        app.add_systems(Startup, load_textures);
+        app.add_systems(
+            Update,
+            update_texture_assets_load_state.run_if(resource_equals(TexturesLoadState::default())),
+        );
+    }
+}
+
+#[derive(Resource, PartialEq)]
+struct TexturesLoadState(RecursiveDependencyLoadState);
+
+impl Default for TexturesLoadState {
+    fn default() -> Self {
+        Self(RecursiveDependencyLoadState::NotLoaded)
+    }
+}
+
+impl TexturesLoadState {
+    pub const LOADED: Self = Self(RecursiveDependencyLoadState::Loaded);
+}
+
+#[derive(Resource, Default, Deref, DerefMut)]
+struct TextureFolderHandle(Handle<LoadedFolder>);
+
+fn load_textures(mut commands: Commands, asset_server: Res<AssetServer>) {
+    let textures_folder_handle = asset_server.load_folder(ASSET_FOLDER_TEXTURES);
+    commands.insert_resource(TextureFolderHandle(textures_folder_handle));
+}
+
+fn update_texture_assets_load_state(
+    mut textures_load_state: ResMut<TexturesLoadState>,
+    textures_folder_handle: Res<TextureFolderHandle>,
+    asset_server: Res<AssetServer>,
+) {
+    textures_load_state.0 =
+        asset_server.recursive_dependency_load_state(textures_folder_handle.id());
+}
+
+pub fn texture_assets_loaded() -> impl Condition<()> {
+    IntoSystem::into_system(resource_equals(TexturesLoadState::LOADED))
+}


### PR DESCRIPTION
Issue:
==============
Closes #5 

What was done:
==============
* Added a textures module that loads image assets and tracks their load state.