### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,6 @@ jobs:
           prefix-key: ${{ vars.CACHE_BUILD_VERSION }}-cargo-${{ runner.os }}
 
       - name: Install alsa and udev
-        if: runner.os == 'linux'
         run: sudo apt update; sudo apt install --no-install-recommends libasound2-dev libudev-dev
 
       - name: Build and run tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install tools for WASM build
         if: matrix.platform == 'web'
         run: |
-          wget -qO- https://github.com/thedodd/trunk/releases/download/v0.18.7/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
+          wget -qO- https://github.com/thedodd/trunk/releases/download/v0.19.3/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,4 +98,4 @@ jobs:
         env:
           BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
         run: |
-          ./butler push ./release/ mnmaita/${{ vars.KEBAB_CASE_GAME_NAME }}:${{ matrix.platform }} --userversion ${{ github.event.release.tag_name }}
+          ./butler push ./release/ ${{ vars.ITCH_IO_USERNAME }}/${{ vars.KEBAB_CASE_GAME_NAME }}:${{ matrix.platform }} --userversion ${{ github.event.release.tag_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,6 @@ jobs:
         if: matrix.platform != 'web'
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Copy binaries to working directory
-        if: matrix.platform != 'web'
-        run: |
-          cp ./target/${{ matrix.target }}/release/${{ matrix.executable_name }} .
-
       - uses: actions/upload-artifact@v4
         if: matrix.platform == 'web'
         with:
@@ -66,10 +61,9 @@ jobs:
         if: matrix.platform != 'web'
         with:
           name: ${{ matrix.platform }}
+          # We don't need to publish the `assets` folder alongside the binary as we are using bevy_embedded_assets
           path: |
-            ./assets/
-            ./${{ vars.KEBAB_CASE_GAME_NAME }}.exe
-            ./${{ vars.KEBAB_CASE_GAME_NAME }}
+            ./target/${{ matrix.target }}/release/${{ matrix.executable_name }}
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,7 @@ jobs:
 
       - name: Install tools for WASM build
         if: matrix.platform == 'web'
-        run: |
-          wget -qO- https://github.com/trunk-rs/trunk/releases/download/v0.19.3/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
+        run: cargo install trunk --locked --version 0.19.3
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -46,7 +45,7 @@ jobs:
 
       - name: Build release
         if: matrix.platform == 'web'
-        run: ./trunk --config Trunk.itch.toml build --release
+        run: trunk build --release --public-url="./"
 
       - name: Build release
         if: matrix.platform != 'web'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install MinGW toolchain
-        if: runner.os == 'linux' && matrix.target == 'x86_64-pc-windows-gnu'
+        if: matrix.target == 'x86_64-pc-windows-gnu'
         run: sudo apt update; sudo apt install -y gcc-mingw-w64-x86-64
 
       - uses: dtolnay/rust-toolchain@stable
@@ -42,7 +42,6 @@ jobs:
           key: ${{ matrix.platform }}
 
       - name: Install alsa and udev
-        if: runner.os == 'linux'
         run: sudo apt update; sudo apt install --no-install-recommends libasound2-dev libudev-dev
 
       - name: Build release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install tools for WASM build
         if: matrix.platform == 'web'
         run: |
-          wget -qO- https://github.com/thedodd/trunk/releases/download/v0.19.3/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
+          wget -qO- https://github.com/trunk-rs/trunk/releases/download/v0.19.3/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,9 +47,6 @@ jobs:
 
       - name: Build release
         if: matrix.platform == 'web'
-        env:
-          # WebGPU requires web_sys unstable APIs
-          RUSTFLAGS: --cfg=web_sys_unstable_apis
         run: ./trunk --config Trunk.itch.toml build --release
 
       - name: Build release

--- a/Trunk.itch.toml
+++ b/Trunk.itch.toml
@@ -1,2 +1,0 @@
-[build]
-public_url = "./"


### PR DESCRIPTION
Issue:
==============
N/A

What was done:
==============
* Bumped `trunk` version used in web release builds to 0.19.3. `trunk` is now installed via `cargo`.
* Removed obsolete `web_sys_unstable_apis` cfg argument when running web builds. This is no longer necessary since `bevy` `0.13.1`.
* Added an environment variable in the repo that is used to set the itch.io username when publishing builds with `butler`.
* Removed a few redundant checks and steps in CI workflows.